### PR TITLE
Determine report-file relative to module-base-directory (Issue #2)

### DIFF
--- a/src/main/java/com/hello2morrow/sonargraph/integration/sonarqube/api/SonargraphSensor.java
+++ b/src/main/java/com/hello2morrow/sonargraph/integration/sonarqube/api/SonargraphSensor.java
@@ -630,17 +630,16 @@ public final class SonargraphSensor implements Sensor
     }
 
     private static Optional<File> determineReportFile(final FileSystem fileSystem, final Settings settings) {
-        final File projectDirectory = fileSystem.baseDir();
         final String reportPathOld = settings.getString(SonargraphPluginBase.REPORT_PATH_OLD);
         final String reportPath = settings.getString(SonargraphPluginBase.REPORT_PATH);
         final File reportFile;
         if (reportPathOld != null)
         {
-            reportFile = lookupRelativeOrAbsoluteFile(reportPathOld, projectDirectory);
+            reportFile = fileSystem.resolvePath(reportPathOld);
         }
         else if (reportPath != null)
         {
-            reportFile = lookupRelativeOrAbsoluteFile(reportPath, projectDirectory);
+            reportFile = fileSystem.resolvePath(reportPath);
         }
         else
         {
@@ -669,11 +668,6 @@ public final class SonargraphSensor implements Sensor
 
     private static boolean fileExistsAndIsReadable(File reportFile) {
         return reportFile.exists() && reportFile.canRead();
-    }
-
-    private static File lookupRelativeOrAbsoluteFile(String path, File root) {
-        File relativeFile = new File(root, path);
-        return fileExistsAndIsReadable(relativeFile) ? relativeFile : new File(path);
     }
 
     private static Optional<File> determineBaseDirectory(final FileSystem fileSystem, final Settings settings)

--- a/src/test/java/com/hello2morrow/sonargraph/integration/sonarqube/api/SonargraphSensorTest.java
+++ b/src/test/java/com/hello2morrow/sonargraph/integration/sonarqube/api/SonargraphSensorTest.java
@@ -55,11 +55,6 @@ import com.hello2morrow.sonargraph.integration.sonarqube.foundation.SonargraphPl
 @SuppressWarnings("rawtypes")
 public class SonargraphSensorTest implements MetricFinder
 {
-    private static final String REPORT_PATH_MULTI_MODULES = "./src/test/AlarmClockMain/AlarmClockMain.xml";
-    private static final String REPORT_PATH_SINGLE_MODULE = "./src/test/report/AlarmClock_Ant.xml";
-
-    private static final String REPORT_CRM = "./src/test/report/CRM-Sonargraph-Report.xml";
-    private static final String REPORT_EXPLORER = "./src/test/explorer/AlarmClockMain.xml";
 
     private RulesProfile rulesProfile;
     private SensorContext sensorContext;
@@ -72,7 +67,7 @@ public class SonargraphSensorTest implements MetricFinder
 
     private String getReport()
     {
-        return REPORT_PATH_MULTI_MODULES;
+        return TestHelper.REPORT_PATH_MULTI_MODULES;
     }
 
     @Before
@@ -154,7 +149,7 @@ public class SonargraphSensorTest implements MetricFinder
     @Test
     public void testAnalyseSystemMetricsOfReportWithMultipleModules()
     {
-        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, REPORT_PATH_MULTI_MODULES);
+        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, TestHelper.REPORT_PATH_MULTI_MODULES);
 
         final Project project = mock(Project.class);
         doReturn("hello2morrow:AlarmClockMain").when(project).key();
@@ -182,7 +177,7 @@ public class SonargraphSensorTest implements MetricFinder
     @Test
     public void testAnalyseSystemMetricsOfReportWithSingleModule()
     {
-        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, REPORT_PATH_SINGLE_MODULE);
+        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, TestHelper.REPORT_PATH_SINGLE_MODULE);
 
         final Project project = mock(Project.class);
         doReturn("hello2morrow:AlarmClock").when(project).key();
@@ -202,7 +197,7 @@ public class SonargraphSensorTest implements MetricFinder
     @Test
     public void testHandleDuplicateRuleNotActivated()
     {
-        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, REPORT_PATH_SINGLE_MODULE);
+        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, TestHelper.REPORT_PATH_SINGLE_MODULE);
         rulesProfile = TestHelper.initRulesProfile(SonargraphMetrics.createRuleKey("DuplicateCode"));
         sensor = new SonargraphSensor(this, rulesProfile, settings, moduleFileSystem, TestHelper.initPerspectives());
 
@@ -224,7 +219,7 @@ public class SonargraphSensorTest implements MetricFinder
     @Test
     public void testAnalyseModuleMetrisOfReport()
     {
-        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, REPORT_PATH_MULTI_MODULES);
+        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, TestHelper.REPORT_PATH_MULTI_MODULES);
 
         final Project project = mock(Project.class);
         doReturn("AlarmClock").when(project).key();
@@ -255,7 +250,7 @@ public class SonargraphSensorTest implements MetricFinder
     @Test
     public void testAnalyseSingleModuleProject()
     {
-        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, REPORT_CRM);
+        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, TestHelper.REPORT_CRM);
         final Project project = mock(Project.class);
         doReturn("com.hello2morrow:crm-domain-example").when(project).key();
         doReturn("crm-domain-example").when(project).name();
@@ -284,7 +279,7 @@ public class SonargraphSensorTest implements MetricFinder
     @Test
     public void testAnalyseExplorerReport()
     {
-        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, REPORT_EXPLORER);
+        settings.setProperty(SonargraphPluginBase.REPORT_PATH_OLD, TestHelper.REPORT_EXPLORER);
 
         final Project project = mock(Project.class);
         doReturn("AlarmClock").when(project).key();

--- a/src/test/java/com/hello2morrow/sonargraph/integration/sonarqube/api/TestHelper.java
+++ b/src/test/java/com/hello2morrow/sonargraph/integration/sonarqube/api/TestHelper.java
@@ -57,6 +57,11 @@ import com.hello2morrow.sonargraph.integration.sonarqube.foundation.SonargraphPl
 
 public final class TestHelper
 {
+    public static final String REPORT_PATH_MULTI_MODULES = "src/test/AlarmClockMain/AlarmClockMain.xml";
+    public static final String REPORT_PATH_SINGLE_MODULE = "src/test/report/AlarmClock_Ant.xml";
+    public static final String REPORT_CRM = new File("./src/test/report/CRM-Sonargraph-Report.xml").getAbsolutePath();
+    public static final String REPORT_EXPLORER = "src/test/explorer/AlarmClockMain.xml";
+
     private static Map<String, Measure<?>> s_systemMetrics;
     private static final List<InputFile> inputFiles = new ArrayList<>();
 
@@ -163,6 +168,14 @@ public final class TestHelper
             });
             inputFiles.add(file);
         }
+
+        when (fileSystem.resolvePath(any())).thenAnswer(new Answer<File>() {
+            @Override
+            public File answer(InvocationOnMock mock) throws Throwable {
+                File f = new File(String.valueOf(mock.getArguments()[0]));
+                return (f.isAbsolute()) ? f : new File("./" +  f.getPath());
+            }
+        });
 
         when(fileSystem.hasFiles(any(FilePredicate.class))).thenAnswer(new Answer<Boolean>()
         {


### PR DESCRIPTION
Hi,

i've changed the SonargraphSensor in such a way that it uses the FileSystem to resove the path to the file-system. This way it is either possible to set an absolute path (e.g. to the report in the root-project) or an relative path based on a modules base-dir.
